### PR TITLE
feat(ui): design system + Sprint 1 core screens

### DIFF
--- a/apps/refinup_flutter/lib/core/theme/app_colors.dart
+++ b/apps/refinup_flutter/lib/core/theme/app_colors.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+/// RefinUp design-system color tokens (tokens.md)
+class AppColors {
+  AppColors._();
+
+  // Brand
+  static const Color primary = Color(0xFF6366F1); // Indigo 500
+  static const Color primaryDark = Color(0xFF818CF8); // Indigo 400
+  static const Color primaryContainer = Color(0xFFE0E7FF); // Indigo 100
+  static const Color primaryContainerDark = Color(0xFF3730A3); // Indigo 800
+
+  static const Color secondary = Color(0xFF10B981); // Emerald 500
+  static const Color secondaryDark = Color(0xFF34D399); // Emerald 400
+
+  static const Color tertiary = Color(0xFFF59E0B); // Amber 500
+  static const Color tertiaryDark = Color(0xFFFCD34D); // Amber 300
+
+  // Surface
+  static const Color surface = Color(0xFFFFFFFF);
+  static const Color surfaceDark = Color(0xFF0F172A); // Slate 900
+  static const Color surfaceVariant = Color(0xFFF8FAFC); // Slate 50
+  static const Color surfaceVariantDark = Color(0xFF1E293B); // Slate 800
+  static const Color background = Color(0xFFF1F5F9); // Slate 100
+  static const Color backgroundDark = Color(0xFF020617); // Slate 950
+
+  // Semantic
+  static const Color onSurface = Color(0xFF0F172A); // Slate 900
+  static const Color onSurfaceDark = Color(0xFFF8FAFC); // Slate 50
+  static const Color onSurfaceVariant = Color(0xFF475569); // Slate 600
+  static const Color onSurfaceVariantDark = Color(0xFF94A3B8); // Slate 400
+  static const Color error = Color(0xFFEF4444); // Red 500
+  static const Color errorDark = Color(0xFFFCA5A5); // Red 300
+  static const Color outline = Color(0xFFCBD5E1); // Slate 300
+  static const Color outlineDark = Color(0xFF334155); // Slate 700
+
+  // AI Round Role Colors
+  static const Color roleCritic = Color(0xFFEF4444); // Red
+  static const Color roleOptimist = Color(0xFF10B981); // Emerald
+  static const Color rolePragmatist = Color(0xFF6366F1); // Indigo
+  static const Color roleDevil = Color(0xFFF59E0B); // Amber
+
+  static Color roleColor(String role) {
+    switch (role.toLowerCase()) {
+      case 'critic':
+        return roleCritic;
+      case 'optimist':
+        return roleOptimist;
+      case 'pragmatist':
+        return rolePragmatist;
+      case 'devil':
+      case "devil's advocate":
+        return roleDevil;
+      default:
+        return primary;
+    }
+  }
+}

--- a/apps/refinup_flutter/lib/core/theme/app_spacing.dart
+++ b/apps/refinup_flutter/lib/core/theme/app_spacing.dart
@@ -1,0 +1,27 @@
+/// RefinUp spacing tokens (4px base grid)
+class AppSpacing {
+  AppSpacing._();
+
+  static const double xs = 4.0;
+  static const double sm = 8.0;
+  static const double md = 16.0;
+  static const double lg = 24.0;
+  static const double xl = 32.0;
+  static const double xxl = 48.0;
+  static const double xxxl = 64.0;
+
+  /// Default page horizontal padding
+  static const double pagePaddingH = 20.0;
+
+  /// Default page vertical padding
+  static const double pagePaddingV = 24.0;
+
+  /// Card internal padding
+  static const double cardPadding = 16.0;
+
+  /// Standard border radius
+  static const double radiusSm = 8.0;
+  static const double radiusMd = 12.0;
+  static const double radiusLg = 16.0;
+  static const double radiusXl = 24.0;
+}

--- a/apps/refinup_flutter/lib/core/theme/app_text_styles.dart
+++ b/apps/refinup_flutter/lib/core/theme/app_text_styles.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+
+/// RefinUp typography tokens (tokens.md — Material 3 type scale)
+class AppTextStyles {
+  AppTextStyles._();
+
+  static const TextStyle displayLarge = TextStyle(
+    fontSize: 57,
+    fontWeight: FontWeight.w400,
+    height: 64 / 57,
+  );
+
+  static const TextStyle displayMedium = TextStyle(
+    fontSize: 45,
+    fontWeight: FontWeight.w400,
+    height: 52 / 45,
+  );
+
+  static const TextStyle headlineLarge = TextStyle(
+    fontSize: 32,
+    fontWeight: FontWeight.w400,
+    height: 40 / 32,
+  );
+
+  static const TextStyle headlineMedium = TextStyle(
+    fontSize: 28,
+    fontWeight: FontWeight.w400,
+    height: 36 / 28,
+  );
+
+  static const TextStyle headlineSmall = TextStyle(
+    fontSize: 24,
+    fontWeight: FontWeight.w400,
+    height: 32 / 24,
+  );
+
+  static const TextStyle titleLarge = TextStyle(
+    fontSize: 22,
+    fontWeight: FontWeight.w500,
+    height: 28 / 22,
+  );
+
+  static const TextStyle titleMedium = TextStyle(
+    fontSize: 16,
+    fontWeight: FontWeight.w500,
+    height: 24 / 16,
+  );
+
+  static const TextStyle bodyLarge = TextStyle(
+    fontSize: 16,
+    fontWeight: FontWeight.w400,
+    height: 24 / 16,
+  );
+
+  static const TextStyle bodyMedium = TextStyle(
+    fontSize: 14,
+    fontWeight: FontWeight.w400,
+    height: 20 / 14,
+  );
+
+  static const TextStyle bodySmall = TextStyle(
+    fontSize: 12,
+    fontWeight: FontWeight.w400,
+    height: 16 / 12,
+  );
+
+  static const TextStyle labelLarge = TextStyle(
+    fontSize: 14,
+    fontWeight: FontWeight.w500,
+    height: 20 / 14,
+  );
+
+  static const TextStyle labelMedium = TextStyle(
+    fontSize: 12,
+    fontWeight: FontWeight.w500,
+    height: 16 / 12,
+  );
+
+  static const TextStyle labelSmall = TextStyle(
+    fontSize: 11,
+    fontWeight: FontWeight.w500,
+    height: 16 / 11,
+  );
+}

--- a/apps/refinup_flutter/lib/core/theme/app_theme.dart
+++ b/apps/refinup_flutter/lib/core/theme/app_theme.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'app_colors.dart';
+
+/// RefinUp Material 3 theme configuration
+class AppTheme {
+  AppTheme._();
+
+  static ThemeData get light => ThemeData(
+        useMaterial3: true,
+        colorScheme: const ColorScheme.light(
+          primary: AppColors.primary,
+          onPrimary: Colors.white,
+          primaryContainer: AppColors.primaryContainer,
+          secondary: AppColors.secondary,
+          tertiary: AppColors.tertiary,
+          surface: AppColors.surface,
+          onSurface: AppColors.onSurface,
+          error: AppColors.error,
+          outline: AppColors.outline,
+        ),
+        scaffoldBackgroundColor: AppColors.background,
+        cardTheme: CardThemeData(
+          color: AppColors.surface,
+          elevation: 0,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+            side: const BorderSide(color: AppColors.outline),
+          ),
+        ),
+        inputDecorationTheme: InputDecorationTheme(
+          filled: true,
+          fillColor: AppColors.surfaceVariant,
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(12),
+            borderSide: const BorderSide(color: AppColors.outline),
+          ),
+          enabledBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(12),
+            borderSide: const BorderSide(color: AppColors.outline),
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(12),
+            borderSide: const BorderSide(color: AppColors.primary, width: 2),
+          ),
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: 12,
+          ),
+        ),
+        elevatedButtonTheme: ElevatedButtonThemeData(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: AppColors.primary,
+            foregroundColor: Colors.white,
+            minimumSize: const Size(double.infinity, 52),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+            elevation: 0,
+          ),
+        ),
+        chipTheme: ChipThemeData(
+          backgroundColor: AppColors.primaryContainer,
+          labelStyle: const TextStyle(
+            color: AppColors.primary,
+            fontWeight: FontWeight.w500,
+          ),
+          side: BorderSide.none,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8),
+          ),
+        ),
+        appBarTheme: const AppBarTheme(
+          backgroundColor: AppColors.surface,
+          foregroundColor: AppColors.onSurface,
+          elevation: 0,
+          centerTitle: false,
+          surfaceTintColor: Colors.transparent,
+        ),
+      );
+
+  static ThemeData get dark => ThemeData(
+        useMaterial3: true,
+        colorScheme: const ColorScheme.dark(
+          primary: AppColors.primaryDark,
+          onPrimary: AppColors.surfaceDark,
+          primaryContainer: AppColors.primaryContainerDark,
+          secondary: AppColors.secondaryDark,
+          tertiary: AppColors.tertiaryDark,
+          surface: AppColors.surfaceDark,
+          onSurface: AppColors.onSurfaceDark,
+          error: AppColors.errorDark,
+          outline: AppColors.outlineDark,
+        ),
+        scaffoldBackgroundColor: AppColors.backgroundDark,
+        cardTheme: CardThemeData(
+          color: AppColors.surfaceVariantDark,
+          elevation: 0,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+            side: const BorderSide(color: AppColors.outlineDark),
+          ),
+        ),
+        inputDecorationTheme: InputDecorationTheme(
+          filled: true,
+          fillColor: AppColors.surfaceVariantDark,
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(12),
+            borderSide: const BorderSide(color: AppColors.outlineDark),
+          ),
+          enabledBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(12),
+            borderSide: const BorderSide(color: AppColors.outlineDark),
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(12),
+            borderSide:
+                const BorderSide(color: AppColors.primaryDark, width: 2),
+          ),
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: 12,
+          ),
+        ),
+        elevatedButtonTheme: ElevatedButtonThemeData(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: AppColors.primaryDark,
+            foregroundColor: AppColors.surfaceDark,
+            minimumSize: const Size(double.infinity, 52),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+            elevation: 0,
+          ),
+        ),
+        appBarTheme: const AppBarTheme(
+          backgroundColor: AppColors.surfaceDark,
+          foregroundColor: AppColors.onSurfaceDark,
+          elevation: 0,
+          centerTitle: false,
+          surfaceTintColor: Colors.transparent,
+        ),
+      );
+}

--- a/apps/refinup_flutter/lib/features/refinement/screens/idea_input_screen.dart
+++ b/apps/refinup_flutter/lib/features/refinement/screens/idea_input_screen.dart
@@ -1,0 +1,280 @@
+import 'package:flutter/material.dart';
+import '../../../core/theme/app_colors.dart';
+import '../../../core/theme/app_spacing.dart';
+import '../../../core/theme/app_text_styles.dart';
+import '../../../shared/widgets/step_indicator.dart';
+
+/// First screen: user inputs their raw idea.
+/// WCAG 2.1 AA: form fields have semantic labels, character count announced.
+class IdeaInputScreen extends StatefulWidget {
+  const IdeaInputScreen({super.key});
+
+  @override
+  State<IdeaInputScreen> createState() => _IdeaInputScreenState();
+}
+
+class _IdeaInputScreenState extends State<IdeaInputScreen> {
+  final _controller = TextEditingController();
+  final _focusNode = FocusNode();
+  static const int _maxLength = 5000;
+
+  int get _charCount => _controller.text.length;
+  bool get _canSubmit => _charCount >= 10 && _charCount <= _maxLength;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _onSubmit() {
+    if (!_canSubmit) return;
+    // TODO(sprint1): navigate to refinement screen with idea text
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('Idea submitted: ${_controller.text.substring(0, 40)}...'),
+        backgroundColor: AppColors.secondary,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isNearLimit = _charCount > _maxLength * 0.8;
+    final isOverLimit = _charCount > _maxLength;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('RefinUp'),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.only(right: AppSpacing.md),
+            child: Semantics(
+              label: 'How it works',
+              child: IconButton(
+                icon: const Icon(Icons.info_outline),
+                onPressed: () => _showHowItWorks(context),
+              ),
+            ),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.pagePaddingH,
+            vertical: AppSpacing.pagePaddingV,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Step indicator — 3 steps: Input → Refine → Result
+              StepIndicator(
+                steps: const [
+                  StepInfo(label: 'Your Idea', state: StepState.active),
+                  StepInfo(label: 'AI Rounds', state: StepState.pending, roleTag: 'Multi-AI'),
+                  StepInfo(label: 'Result', state: StepState.pending),
+                ],
+                currentStep: 0,
+              ),
+              const SizedBox(height: AppSpacing.xl),
+
+              Text(
+                'What\'s your idea?',
+                style: AppTextStyles.headlineMedium.copyWith(
+                  color: theme.colorScheme.onSurface,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                'Share any idea — product, business, creative project, or problem to solve. '
+                'Multiple AI perspectives will refine it for you.',
+                style: AppTextStyles.bodyMedium.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.lg),
+
+              Expanded(
+                child: Semantics(
+                  label: 'Idea input field, maximum $_maxLength characters',
+                  child: TextField(
+                    controller: _controller,
+                    focusNode: _focusNode,
+                    maxLines: null,
+                    expands: true,
+                    textAlignVertical: TextAlignVertical.top,
+                    style: AppTextStyles.bodyLarge.copyWith(
+                      color: theme.colorScheme.onSurface,
+                    ),
+                    decoration: InputDecoration(
+                      hintText:
+                          'e.g., A mobile app that helps remote teams build genuine friendships through weekly micro-challenges...',
+                      hintStyle: AppTextStyles.bodyLarge.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                      alignLabelWithHint: true,
+                    ),
+                  ),
+                ),
+              ),
+
+              const SizedBox(height: AppSpacing.sm),
+
+              // Character count
+              Semantics(
+                liveRegion: true,
+                label: '$_charCount of $_maxLength characters',
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    Text(
+                      '$_charCount / $_maxLength',
+                      style: AppTextStyles.bodySmall.copyWith(
+                        color: isOverLimit
+                            ? AppColors.error
+                            : isNearLimit
+                                ? AppColors.tertiary
+                                : theme.colorScheme.onSurfaceVariant,
+                        fontWeight: isNearLimit ? FontWeight.w600 : FontWeight.w400,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              const SizedBox(height: AppSpacing.md),
+
+              Semantics(
+                button: true,
+                enabled: _canSubmit,
+                label: 'Refine my idea with AI',
+                child: ElevatedButton(
+                  onPressed: _canSubmit ? _onSubmit : null,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: const [
+                      Icon(Icons.auto_awesome),
+                      SizedBox(width: AppSpacing.sm),
+                      Text('Refine My Idea'),
+                    ],
+                  ),
+                ),
+              ),
+
+              const SizedBox(height: AppSpacing.md),
+
+              // Social proof / expectation setting
+              Semantics(
+                label: '3 AI perspectives, takes about 30 seconds',
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(Icons.groups_2, size: 16, color: AppColors.onSurfaceVariant),
+                    const SizedBox(width: AppSpacing.xs),
+                    Text(
+                      '3 AI perspectives · ~30 seconds',
+                      style: AppTextStyles.bodySmall.copyWith(
+                        color: AppColors.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _showHowItWorks(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      builder: (_) => Padding(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('How RefinUp Works',
+                style: AppTextStyles.headlineSmall),
+            const SizedBox(height: AppSpacing.md),
+            _HowItWorksItem(
+              color: AppColors.roleOptimist,
+              role: 'Optimist',
+              description: 'Finds the strongest potential and what makes your idea unique.',
+            ),
+            _HowItWorksItem(
+              color: AppColors.roleCritic,
+              role: 'Critic',
+              description: 'Identifies real risks and gaps — the hard questions investors would ask.',
+            ),
+            _HowItWorksItem(
+              color: AppColors.rolePragmatist,
+              role: 'Pragmatist',
+              description: 'Turns insights into a concrete, actionable next step plan.',
+            ),
+            const SizedBox(height: AppSpacing.md),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _HowItWorksItem extends StatelessWidget {
+  final Color color;
+  final String role;
+  final String description;
+
+  const _HowItWorksItem({
+    required this.color,
+    required this.role,
+    required this.description,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 12,
+            height: 12,
+            margin: const EdgeInsets.only(top: 4),
+            decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+          ),
+          const SizedBox(width: AppSpacing.sm),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(role,
+                    style: AppTextStyles.labelLarge.copyWith(
+                        color: color, fontWeight: FontWeight.w700)),
+                Text(description,
+                    style: AppTextStyles.bodySmall.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant)),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/refinup_flutter/lib/features/refinement/screens/refinement_screen.dart
+++ b/apps/refinup_flutter/lib/features/refinement/screens/refinement_screen.dart
@@ -1,0 +1,335 @@
+import 'package:flutter/material.dart';
+import '../../../core/theme/app_colors.dart';
+import '../../../core/theme/app_spacing.dart';
+import '../../../core/theme/app_text_styles.dart';
+import '../../../shared/widgets/round_badge.dart';
+import '../../../shared/widgets/step_indicator.dart';
+import '../../../shared/widgets/streaming_text.dart';
+
+/// Holds the output of one AI round
+class RoundOutput {
+  final String role;
+  final String text;
+  final bool isStreaming;
+
+  const RoundOutput({
+    required this.role,
+    required this.text,
+    this.isStreaming = false,
+  });
+}
+
+/// Shows AI refinement rounds sequentially with streaming text.
+/// WCAG 2.1 AA: live regions, semantics on each round card.
+class RefinementScreen extends StatelessWidget {
+  final String ideaText;
+  final List<RoundOutput> rounds;
+  final int currentRoundIndex;
+  final bool isComplete;
+  final VoidCallback? onShare;
+  final VoidCallback? onNewIdea;
+
+  const RefinementScreen({
+    super.key,
+    required this.ideaText,
+    required this.rounds,
+    required this.currentRoundIndex,
+    required this.isComplete,
+    this.onShare,
+    this.onNewIdea,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    // Build step list from rounds
+    final steps = [
+      const StepInfo(label: 'Your Idea', state: StepState.completed),
+      ...rounds.asMap().entries.map((e) {
+        final StepState state;
+        if (e.key < currentRoundIndex) {
+          state = StepState.completed;
+        } else if (e.key == currentRoundIndex) {
+          state = StepState.active;
+        } else {
+          state = StepState.pending;
+        }
+        return StepInfo(
+          label: 'Round ${e.key + 1}',
+          roleTag: e.value.role,
+          state: state,
+        );
+      }),
+      StepInfo(
+        label: 'Result',
+        state: isComplete ? StepState.completed : StepState.pending,
+      ),
+    ];
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Refining...'),
+        actions: [
+          if (isComplete) ...[
+            Semantics(
+              button: true,
+              label: 'Share your refined idea',
+              child: IconButton(
+                icon: const Icon(Icons.share),
+                onPressed: onShare,
+              ),
+            ),
+          ],
+        ],
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            // Progress bar
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSpacing.pagePaddingH,
+                vertical: AppSpacing.md,
+              ),
+              child: StepIndicator(
+                steps: steps,
+                currentStep: isComplete
+                    ? steps.length - 1
+                    : currentRoundIndex + 1, // +1 for "Your Idea" step
+              ),
+            ),
+
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.pagePaddingH,
+                  vertical: AppSpacing.sm,
+                ),
+                children: [
+                  // Original idea card
+                  _IdeaCard(ideaText: ideaText),
+                  const SizedBox(height: AppSpacing.md),
+
+                  // Round cards
+                  ...rounds.asMap().entries.map((e) {
+                    final isActive = e.key == currentRoundIndex;
+                    final isVisible = e.key <= currentRoundIndex;
+                    if (!isVisible) return const SizedBox.shrink();
+                    return Padding(
+                      padding: const EdgeInsets.only(bottom: AppSpacing.md),
+                      child: _RoundCard(
+                        roundNumber: e.key + 1,
+                        output: e.value,
+                        isActive: isActive,
+                      ),
+                    );
+                  }),
+
+                  if (isComplete) ...[
+                    const SizedBox(height: AppSpacing.sm),
+                    _CompletionActions(
+                      onShare: onShare,
+                      onNewIdea: onNewIdea,
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _IdeaCard extends StatelessWidget {
+  final String ideaText;
+
+  const _IdeaCard({required this.ideaText});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Semantics(
+      label: 'Your original idea',
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.cardPadding),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  const Icon(Icons.lightbulb_outline,
+                      size: 16, color: AppColors.tertiary),
+                  const SizedBox(width: AppSpacing.xs),
+                  Text(
+                    'Your Idea',
+                    style: AppTextStyles.labelLarge.copyWith(
+                      color: AppColors.tertiary,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                ideaText,
+                style: AppTextStyles.bodyMedium.copyWith(
+                  color: theme.colorScheme.onSurface,
+                ),
+                maxLines: 4,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RoundCard extends StatelessWidget {
+  final int roundNumber;
+  final RoundOutput output;
+  final bool isActive;
+
+  const _RoundCard({
+    required this.roundNumber,
+    required this.output,
+    required this.isActive,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final roleColor = AppColors.roleColor(output.role);
+
+    return Semantics(
+      label: 'Round $roundNumber: ${output.role} perspective',
+      child: AnimatedOpacity(
+        opacity: isActive || !output.isStreaming ? 1.0 : 0.6,
+        duration: const Duration(milliseconds: 300),
+        child: Card(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppSpacing.radiusLg),
+            side: BorderSide(
+              color: isActive ? roleColor.withOpacity(0.4) : Colors.transparent,
+              width: 1.5,
+            ),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.cardPadding),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Text(
+                      'Round $roundNumber',
+                      style: AppTextStyles.labelMedium.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    const SizedBox(width: AppSpacing.sm),
+                    RoundBadge(role: output.role),
+                    if (output.isStreaming) ...[
+                      const Spacer(),
+                      const _PulsingDot(),
+                    ],
+                  ],
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                StreamingText(
+                  text: output.text,
+                  isStreaming: output.isStreaming,
+                  style: AppTextStyles.bodyMedium.copyWith(
+                    color: Theme.of(context).colorScheme.onSurface,
+                    height: 1.6,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PulsingDot extends StatefulWidget {
+  const _PulsingDot();
+
+  @override
+  State<_PulsingDot> createState() => _PulsingDotState();
+}
+
+class _PulsingDotState extends State<_PulsingDot>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _c;
+
+  @override
+  void initState() {
+    super.initState();
+    _c = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 800),
+    )..repeat(reverse: true);
+  }
+
+  @override
+  void dispose() {
+    _c.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FadeTransition(
+      opacity: _c,
+      child: Container(
+        width: 8,
+        height: 8,
+        decoration: const BoxDecoration(
+          color: AppColors.secondary,
+          shape: BoxShape.circle,
+        ),
+      ),
+    );
+  }
+}
+
+class _CompletionActions extends StatelessWidget {
+  final VoidCallback? onShare;
+  final VoidCallback? onNewIdea;
+
+  const _CompletionActions({this.onShare, this.onNewIdea});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Semantics(
+          button: true,
+          label: 'Share your refined idea',
+          child: ElevatedButton.icon(
+            onPressed: onShare,
+            icon: const Icon(Icons.share),
+            label: const Text('Share My Refined Idea'),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        Semantics(
+          button: true,
+          label: 'Start a new idea',
+          child: OutlinedButton(
+            onPressed: onNewIdea,
+            child: const Text('Refine Another Idea'),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.xxl),
+      ],
+    );
+  }
+}

--- a/apps/refinup_flutter/lib/main.dart
+++ b/apps/refinup_flutter/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:refinup_model_registry/refinup_model_registry.dart';
+import 'core/theme/app_theme.dart';
+import 'features/refinement/screens/idea_input_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -12,87 +14,17 @@ void main() async {
 }
 
 class RefinUpApp extends StatelessWidget {
-  const RefinUpApp({Key? key}) : super(key: key);
+  const RefinUpApp({super.key});
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'RefinUp',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
-        useMaterial3: true,
-      ),
-      home: const HomeScreen(),
-    );
-  }
-}
-
-class HomeScreen extends StatefulWidget {
-  const HomeScreen({Key? key}) : super(key: key);
-
-  @override
-  State<HomeScreen> createState() => _HomeScreenState();
-}
-
-class _HomeScreenState extends State<HomeScreen> {
-  late ModelRegistry _registry;
-  String? _selectedDomain;
-
-  @override
-  void initState() {
-    super.initState();
-    _registry = ModelRegistry();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('RefinUp'),
-        elevation: 0,
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Text(
-              'Welcome to RefinUp v2',
-              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 16),
-            const Text(
-              'Sprint 0: Monorepo Setup Complete',
-              style: TextStyle(fontSize: 16),
-            ),
-            const SizedBox(height: 24),
-
-            // Display available models
-            const Text(
-              'Available Models:',
-              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 12),
-            Expanded(
-              child: ListView.builder(
-                itemCount: _registry.models.length,
-                itemBuilder: (context, index) {
-                  final model = _registry.models.values.toList()[index];
-                  return Card(
-                    child: ListTile(
-                      title: Text(model.id),
-                      subtitle: Text('Provider: ${model.provider}'),
-                      trailing: Chip(
-                        label: Text('${model.capabilityScore}/10'),
-                      ),
-                    ),
-                  );
-                },
-              ),
-            ),
-          ],
-        ),
-      ),
+      debugShowCheckedModeBanner: false,
+      theme: AppTheme.light,
+      darkTheme: AppTheme.dark,
+      themeMode: ThemeMode.system,
+      home: const IdeaInputScreen(),
     );
   }
 }

--- a/apps/refinup_flutter/lib/shared/widgets/round_badge.dart
+++ b/apps/refinup_flutter/lib/shared/widgets/round_badge.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import '../../core/theme/app_colors.dart';
+import '../../core/theme/app_text_styles.dart';
+import '../../core/theme/app_spacing.dart';
+
+/// Colored role badge for AI refinement rounds.
+/// WCAG 2.1 AA: uses Semantics to announce role name to screen readers.
+class RoundBadge extends StatelessWidget {
+  final String role;
+  final bool compact;
+
+  const RoundBadge({
+    super.key,
+    required this.role,
+    this.compact = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = AppColors.roleColor(role);
+    final bgColor = color.withOpacity(0.12);
+
+    return Semantics(
+      label: 'AI role: $role',
+      child: Container(
+        padding: EdgeInsets.symmetric(
+          horizontal: compact ? AppSpacing.xs : AppSpacing.sm,
+          vertical: compact ? 2 : AppSpacing.xs,
+        ),
+        decoration: BoxDecoration(
+          color: bgColor,
+          borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+          border: Border.all(color: color.withOpacity(0.3)),
+        ),
+        child: Text(
+          role,
+          style: (compact ? AppTextStyles.labelSmall : AppTextStyles.labelMedium)
+              .copyWith(color: color, fontWeight: FontWeight.w600),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/refinup_flutter/lib/shared/widgets/step_indicator.dart
+++ b/apps/refinup_flutter/lib/shared/widgets/step_indicator.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import '../../core/theme/app_colors.dart';
+import '../../core/theme/app_spacing.dart';
+import '../../core/theme/app_text_styles.dart';
+
+enum StepState { pending, active, completed }
+
+class StepInfo {
+  final String label;
+  final String? roleTag;
+  final StepState state;
+
+  const StepInfo({
+    required this.label,
+    this.roleTag,
+    this.state = StepState.pending,
+  });
+}
+
+/// Horizontal step indicator for AI refinement rounds.
+/// WCAG 2.1 AA: each step has Semantics label announcing progress.
+class StepIndicator extends StatelessWidget {
+  final List<StepInfo> steps;
+  final int currentStep;
+
+  const StepIndicator({
+    super.key,
+    required this.steps,
+    required this.currentStep,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Semantics(
+      label: 'Step ${currentStep + 1} of ${steps.length}: ${steps[currentStep].label}',
+      child: Row(
+        children: List.generate(steps.length * 2 - 1, (i) {
+          if (i.isOdd) {
+            // Connector line
+            final leftCompleted = (i ~/ 2) < currentStep;
+            return Expanded(
+              child: Container(
+                height: 2,
+                color: leftCompleted ? AppColors.primary : AppColors.outline,
+              ),
+            );
+          }
+          final stepIndex = i ~/ 2;
+          final step = steps[stepIndex];
+          return _StepDot(
+            index: stepIndex,
+            info: step,
+            isCurrent: stepIndex == currentStep,
+            colorScheme: colorScheme,
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class _StepDot extends StatelessWidget {
+  final int index;
+  final StepInfo info;
+  final bool isCurrent;
+  final ColorScheme colorScheme;
+
+  const _StepDot({
+    required this.index,
+    required this.info,
+    required this.isCurrent,
+    required this.colorScheme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final roleColor = info.roleTag != null
+        ? AppColors.roleColor(info.roleTag!)
+        : AppColors.primary;
+
+    Color bgColor;
+    Color borderColor;
+    Widget child;
+
+    switch (info.state) {
+      case StepState.completed:
+        bgColor = AppColors.primary;
+        borderColor = AppColors.primary;
+        child = const Icon(Icons.check, size: 14, color: Colors.white);
+        break;
+      case StepState.active:
+        bgColor = Colors.white;
+        borderColor = roleColor;
+        child = Text(
+          '${index + 1}',
+          style: AppTextStyles.labelSmall.copyWith(
+            color: roleColor,
+            fontWeight: FontWeight.bold,
+          ),
+        );
+        break;
+      case StepState.pending:
+        bgColor = Colors.white;
+        borderColor = AppColors.outline;
+        child = Text(
+          '${index + 1}',
+          style: AppTextStyles.labelSmall.copyWith(
+            color: AppColors.onSurfaceVariant,
+          ),
+        );
+        break;
+    }
+
+    return Semantics(
+      label: '${info.label}, step ${index + 1}, ${info.state.name}',
+      excludeSemantics: true,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          AnimatedContainer(
+            duration: const Duration(milliseconds: 250),
+            width: isCurrent ? 32 : 28,
+            height: isCurrent ? 32 : 28,
+            decoration: BoxDecoration(
+              color: bgColor,
+              shape: BoxShape.circle,
+              border: Border.all(
+                color: borderColor,
+                width: isCurrent ? 2.5 : 1.5,
+              ),
+              boxShadow: isCurrent
+                  ? [
+                      BoxShadow(
+                        color: roleColor.withOpacity(0.3),
+                        blurRadius: 8,
+                        spreadRadius: 1,
+                      ),
+                    ]
+                  : null,
+            ),
+            child: Center(child: child),
+          ),
+          if (info.roleTag != null) ...[
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              info.roleTag!,
+              style: AppTextStyles.labelSmall.copyWith(
+                color: isCurrent ? roleColor : AppColors.onSurfaceVariant,
+                fontWeight:
+                    isCurrent ? FontWeight.w600 : FontWeight.w400,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/apps/refinup_flutter/lib/shared/widgets/streaming_text.dart
+++ b/apps/refinup_flutter/lib/shared/widgets/streaming_text.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import '../../core/theme/app_colors.dart';
+import '../../core/theme/app_text_styles.dart';
+
+/// Displays streaming AI text with an animated cursor.
+/// Falls back to a thinking indicator when text is empty.
+/// WCAG 2.1 AA: announces content to screen readers when complete.
+class StreamingText extends StatefulWidget {
+  final String text;
+  final bool isStreaming;
+  final TextStyle? style;
+
+  const StreamingText({
+    super.key,
+    required this.text,
+    required this.isStreaming,
+    this.style,
+  });
+
+  @override
+  State<StreamingText> createState() => _StreamingTextState();
+}
+
+class _StreamingTextState extends State<StreamingText>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _cursorController;
+  late final Animation<double> _cursorOpacity;
+
+  @override
+  void initState() {
+    super.initState();
+    _cursorController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 500),
+    )..repeat(reverse: true);
+    _cursorOpacity = _cursorController.drive(Tween(begin: 0.0, end: 1.0));
+  }
+
+  @override
+  void dispose() {
+    _cursorController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveStyle =
+        widget.style ?? AppTextStyles.bodyLarge.copyWith(
+          color: Theme.of(context).colorScheme.onSurface,
+        );
+
+    if (widget.text.isEmpty && widget.isStreaming) {
+      return _ThinkingIndicator();
+    }
+
+    return Semantics(
+      liveRegion: widget.isStreaming,
+      label: widget.isStreaming ? 'AI is responding' : widget.text,
+      child: RichText(
+        text: TextSpan(
+          style: effectiveStyle,
+          children: [
+            TextSpan(text: widget.text),
+            if (widget.isStreaming)
+              WidgetSpan(
+                child: FadeTransition(
+                  opacity: _cursorOpacity,
+                  child: Container(
+                    width: 2,
+                    height: effectiveStyle.fontSize ?? 16,
+                    margin: const EdgeInsets.only(left: 1),
+                    color: AppColors.primary,
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ThinkingIndicator extends StatefulWidget {
+  @override
+  State<_ThinkingIndicator> createState() => _ThinkingIndicatorState();
+}
+
+class _ThinkingIndicatorState extends State<_ThinkingIndicator>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1200),
+    )..repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'AI is thinking',
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: List.generate(3, (i) {
+          return AnimatedBuilder(
+            animation: _controller,
+            builder: (context, _) {
+              final offset = (i * 0.33);
+              final t = ((_controller.value + offset) % 1.0);
+              final scale = 0.6 + 0.4 * (t < 0.5 ? t * 2 : (1 - t) * 2);
+              return Transform.scale(
+                scale: scale,
+                child: Container(
+                  width: 8,
+                  height: 8,
+                  margin: const EdgeInsets.symmetric(horizontal: 2),
+                  decoration: const BoxDecoration(
+                    color: AppColors.primary,
+                    shape: BoxShape.circle,
+                  ),
+                ),
+              );
+            },
+          );
+        }),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Implements the full design token system as Flutter Dart classes (AppColors, AppTextStyles, AppTheme light/dark, AppSpacing) directly from `docs/design-system/tokens.md`
- Adds three shared widgets: StepIndicator, RoundBadge, StreamingText — all WCAG 2.1 AA compliant with Semantics
- Adds IdeaInputScreen (5000-char input, how-it-works modal) and RefinementScreen (sequential AI round cards with streaming text, share CTA)
- Wires AppTheme into main.dart

## Test plan
- [ ] Run `flutter analyze` — no errors
- [ ] Light/dark theme toggles correctly on device
- [ ] StepIndicator shows animated state transitions
- [ ] StreamingText shows thinking dots when text empty + isStreaming
- [ ] IdeaInputScreen blocks submit when <10 or >5000 chars
- [ ] Share button appears only when isComplete=true

Closes #2, #3, #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)