### PR TITLE
feat(state+routing): Riverpod provider + go_router + security utils

### DIFF
--- a/apps/refinup_flutter/lib/core/router/app_router.dart
+++ b/apps/refinup_flutter/lib/core/router/app_router.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import '../../features/refinement/screens/idea_input_screen.dart';
+import '../../features/refinement/screens/refinement_flow_screen.dart';
+
+/// Named route paths
+class AppRoutes {
+  AppRoutes._();
+
+  static const String home = '/';
+  static const String refinement = '/refine';
+}
+
+/// App router singleton using go_router
+final appRouter = GoRouter(
+  initialLocation: AppRoutes.home,
+  routes: [
+    GoRoute(
+      path: AppRoutes.home,
+      name: 'home',
+      builder: (context, state) => const IdeaInputScreen(),
+    ),
+    GoRoute(
+      path: AppRoutes.refinement,
+      name: 'refinement',
+      builder: (context, state) {
+        final ideaText = state.extra as String? ?? '';
+        return RefinementFlowScreen(ideaText: ideaText);
+      },
+    ),
+  ],
+  // Error page
+  errorBuilder: (context, state) => Scaffold(
+    body: Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.error_outline, size: 48),
+          const SizedBox(height: 16),
+          Text('Page not found: ${state.uri}'),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () => context.go(AppRoutes.home),
+            child: const Text('Go Home'),
+          ),
+        ],
+      ),
+    ),
+  ),
+);

--- a/apps/refinup_flutter/lib/core/utils/app_events.dart
+++ b/apps/refinup_flutter/lib/core/utils/app_events.dart
@@ -1,0 +1,52 @@
+/// PostHog event taxonomy for RefinUp.
+/// Source of truth: docs/analytics/event-taxonomy.md
+/// Rule: Never add tracking code without a corresponding event constant here.
+class AppEvents {
+  AppEvents._();
+
+  // Idea Input
+  static const String ideaStarted = 'idea_started';
+  static const String ideaSubmitted = 'idea_submitted';
+  static const String ideaInputCleared = 'idea_input_cleared';
+
+  // Refinement Flow
+  static const String refinementStarted = 'refinement_started';
+  static const String roundStarted = 'round_started';
+  static const String roundCompleted = 'round_completed';
+  static const String refinementCompleted = 'refinement_completed';
+  static const String refinementError = 'refinement_error';
+
+  // Sharing (top growth lever per MASTER_ANALYSIS)
+  static const String shareInitiated = 'share_initiated';
+  static const String shareCopied = 'share_link_copied';
+  static const String shareVia = 'share_via_channel';
+
+  // Onboarding
+  static const String onboardingStarted = 'onboarding_started';
+  static const String onboardingCompleted = 'onboarding_completed';
+  static const String howItWorksOpened = 'how_it_works_opened';
+
+  // Navigation
+  static const String screenViewed = 'screen_viewed';
+
+  // Errors
+  static const String inputValidationError = 'input_validation_error';
+  static const String apiError = 'api_error';
+  static const String quotaExceeded = 'quota_exceeded';
+}
+
+/// Standard property keys for events
+class AppEventProps {
+  AppEventProps._();
+
+  static const String screenName = 'screen_name';
+  static const String ideaLength = 'idea_length';
+  static const String roundNumber = 'round_number';
+  static const String roundRole = 'round_role';
+  static const String modelId = 'model_id';
+  static const String durationMs = 'duration_ms';
+  static const String errorCode = 'error_code';
+  static const String shareChannel = 'share_channel';
+  static const String sessionId = 'session_id';
+  static const String quotaTier = 'quota_tier';
+}

--- a/apps/refinup_flutter/lib/core/utils/input_sanitizer.dart
+++ b/apps/refinup_flutter/lib/core/utils/input_sanitizer.dart
@@ -1,0 +1,76 @@
+import 'dart:math';
+
+/// Input sanitization utility.
+/// Security rule from CLAUDE.md: strip HTML, limit 5000 chars, prevent prompt injection.
+class InputSanitizer {
+  InputSanitizer._();
+
+  static const int maxLength = 5000;
+  static const int minLength = 10;
+
+  // Patterns that look like prompt injection attempts
+  static final _injectionPatterns = [
+    RegExp(r'ignore\s+(previous|above|all)\s+instructions?', caseSensitive: false),
+    RegExp(r'system\s*prompt', caseSensitive: false),
+    RegExp(r'you\s+are\s+now\s+a', caseSensitive: false),
+    RegExp(r'disregard\s+your', caseSensitive: false),
+    RegExp(r'act\s+as\s+if\s+you', caseSensitive: false),
+    RegExp(r'<\|im_start\|>', caseSensitive: false),
+    RegExp(r'\[INST\]', caseSensitive: false),
+  ];
+
+  // Basic HTML tag pattern
+  static final _htmlTagPattern = RegExp(r'<[^>]+>');
+
+  /// Sanitize user idea input.
+  /// Returns a [SanitizeResult] with cleaned text or error.
+  static SanitizeResult sanitize(String raw) {
+    // Strip HTML
+    var text = raw.replaceAll(_htmlTagPattern, '');
+
+    // Normalize whitespace
+    text = text.trim().replaceAll(RegExp(r'[ \t]{2,}'), ' ');
+
+    // Length checks
+    if (text.length < minLength) {
+      return SanitizeResult.error(
+        'Your idea is too short. Please add at least $minLength characters.',
+      );
+    }
+
+    if (text.length > maxLength) {
+      return SanitizeResult.error(
+        'Your idea exceeds $maxLength characters. Please shorten it.',
+      );
+    }
+
+    // Injection detection
+    for (final pattern in _injectionPatterns) {
+      if (pattern.hasMatch(text)) {
+        return SanitizeResult.error(
+          'Your input contains unsupported formatting. Please rephrase your idea.',
+        );
+      }
+    }
+
+    return SanitizeResult.ok(text);
+  }
+
+  /// Truncate text for display (adds ellipsis)
+  static String truncate(String text, int maxChars) {
+    if (text.length <= maxChars) return text;
+    return '${text.substring(0, maxChars)}...';
+  }
+}
+
+class SanitizeResult {
+  final String? text;
+  final String? error;
+
+  bool get isOk => error == null;
+
+  const SanitizeResult._({this.text, this.error});
+
+  factory SanitizeResult.ok(String text) => SanitizeResult._(text: text);
+  factory SanitizeResult.error(String error) => SanitizeResult._(error: error);
+}

--- a/apps/refinup_flutter/lib/features/refinement/providers/refinement_provider.dart
+++ b/apps/refinup_flutter/lib/features/refinement/providers/refinement_provider.dart
@@ -1,0 +1,197 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/utils/input_sanitizer.dart';
+
+/// State of the current refinement session
+enum RefinementStatus {
+  idle,
+  validating,
+  running,
+  complete,
+  error,
+}
+
+class RefinementState {
+  final String rawIdea;
+  final String sanitizedIdea;
+  final RefinementStatus status;
+  final List<RoundState> rounds;
+  final String? errorMessage;
+  final int currentRound;
+
+  const RefinementState({
+    this.rawIdea = '',
+    this.sanitizedIdea = '',
+    this.status = RefinementStatus.idle,
+    this.rounds = const [],
+    this.errorMessage,
+    this.currentRound = 0,
+  });
+
+  RefinementState copyWith({
+    String? rawIdea,
+    String? sanitizedIdea,
+    RefinementStatus? status,
+    List<RoundState>? rounds,
+    String? errorMessage,
+    int? currentRound,
+  }) {
+    return RefinementState(
+      rawIdea: rawIdea ?? this.rawIdea,
+      sanitizedIdea: sanitizedIdea ?? this.sanitizedIdea,
+      status: status ?? this.status,
+      rounds: rounds ?? this.rounds,
+      errorMessage: errorMessage,
+      currentRound: currentRound ?? this.currentRound,
+    );
+  }
+
+  bool get isRunning => status == RefinementStatus.running;
+  bool get isComplete => status == RefinementStatus.complete;
+  bool get hasError => status == RefinementStatus.error;
+}
+
+class RoundState {
+  final String role;
+  final String text;
+  final bool isStreaming;
+  final bool isComplete;
+
+  const RoundState({
+    required this.role,
+    this.text = '',
+    this.isStreaming = false,
+    this.isComplete = false,
+  });
+
+  RoundState copyWith({
+    String? role,
+    String? text,
+    bool? isStreaming,
+    bool? isComplete,
+  }) {
+    return RoundState(
+      role: role ?? this.role,
+      text: text ?? this.text,
+      isStreaming: isStreaming ?? this.isStreaming,
+      isComplete: isComplete ?? this.isComplete,
+    );
+  }
+}
+
+/// Default AI round configuration
+const _defaultRoles = ['Optimist', 'Critic', 'Pragmatist'];
+
+/// Riverpod provider for refinement session state
+class RefinementNotifier extends StateNotifier<RefinementState> {
+  RefinementNotifier() : super(const RefinementState());
+
+  /// Validate and start a refinement session
+  Future<bool> startRefinement(String rawIdea) async {
+    // Phase 1: Validate input
+    state = state.copyWith(
+      rawIdea: rawIdea,
+      status: RefinementStatus.validating,
+    );
+
+    final result = InputSanitizer.sanitize(rawIdea);
+    if (!result.isOk) {
+      state = state.copyWith(
+        status: RefinementStatus.error,
+        errorMessage: result.error,
+      );
+      return false;
+    }
+
+    // Phase 2: Initialize rounds
+    final rounds = _defaultRoles
+        .map((role) => RoundState(role: role))
+        .toList();
+
+    state = state.copyWith(
+      sanitizedIdea: result.text,
+      status: RefinementStatus.running,
+      rounds: rounds,
+      currentRound: 0,
+    );
+
+    // Phase 3: Run rounds sequentially
+    // NOTE: This stub simulates streaming — real impl calls Supabase Edge Function
+    for (int i = 0; i < rounds.length; i++) {
+      await _simulateRound(i);
+    }
+
+    state = state.copyWith(status: RefinementStatus.complete);
+    return true;
+  }
+
+  Future<void> _simulateRound(int roundIndex) async {
+    final role = state.rounds[roundIndex].role;
+
+    // Mark round as streaming
+    final updatedRounds = [...state.rounds];
+    updatedRounds[roundIndex] = updatedRounds[roundIndex].copyWith(
+      isStreaming: true,
+    );
+    state = state.copyWith(rounds: updatedRounds, currentRound: roundIndex);
+
+    // Simulate chunked streaming (500ms delay between chunks)
+    final mockTexts = _getMockText(role);
+    var accumulated = '';
+    for (final chunk in mockTexts) {
+      await Future.delayed(const Duration(milliseconds: 300));
+      accumulated += chunk;
+      final newRounds = [...state.rounds];
+      newRounds[roundIndex] = newRounds[roundIndex].copyWith(
+        text: accumulated,
+        isStreaming: true,
+      );
+      state = state.copyWith(rounds: newRounds);
+    }
+
+    // Mark round complete
+    final finalRounds = [...state.rounds];
+    finalRounds[roundIndex] = finalRounds[roundIndex].copyWith(
+      isStreaming: false,
+      isComplete: true,
+    );
+    state = state.copyWith(rounds: finalRounds);
+  }
+
+  List<String> _getMockText(String role) {
+    switch (role) {
+      case 'Optimist':
+        return [
+          'This idea has real potential. ',
+          'The core value proposition is clear and the timing looks favorable. ',
+          'Key strengths: novel approach, underserved market, and strong differentiation. ',
+          'If executed well, this could become a category-defining product.',
+        ];
+      case 'Critic':
+        return [
+          'Let\'s pressure-test this. ',
+          'Main risks: distribution is unclear, the monetization model needs validation, ',
+          'and competitors with more resources could copy this quickly. ',
+          'The hardest question: why would users switch from their current solution?',
+        ];
+      case 'Pragmatist':
+        return [
+          'Here\'s a concrete 30-day action plan. ',
+          'Week 1: Interview 5 potential users to validate the core assumption. ',
+          'Week 2: Build a no-code prototype and gather feedback. ',
+          'Week 3–4: Iterate based on feedback and define your first paid tier. ',
+          'The most important metric to track: time from sign-up to first "aha moment."',
+        ];
+      default:
+        return ['Analysis complete.'];
+    }
+  }
+
+  void reset() {
+    state = const RefinementState();
+  }
+}
+
+final refinementProvider =
+    StateNotifierProvider<RefinementNotifier, RefinementState>(
+  (ref) => RefinementNotifier(),
+);

--- a/apps/refinup_flutter/lib/features/refinement/screens/idea_input_screen.dart
+++ b/apps/refinup_flutter/lib/features/refinement/screens/idea_input_screen.dart
@@ -1,19 +1,24 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../../core/router/app_router.dart';
 import '../../../core/theme/app_colors.dart';
 import '../../../core/theme/app_spacing.dart';
 import '../../../core/theme/app_text_styles.dart';
+import '../../../core/utils/app_events.dart';
 import '../../../shared/widgets/step_indicator.dart';
+import '../providers/refinement_provider.dart';
 
 /// First screen: user inputs their raw idea.
 /// WCAG 2.1 AA: form fields have semantic labels, character count announced.
-class IdeaInputScreen extends StatefulWidget {
+class IdeaInputScreen extends ConsumerStatefulWidget {
   const IdeaInputScreen({super.key});
 
   @override
-  State<IdeaInputScreen> createState() => _IdeaInputScreenState();
+  ConsumerState<IdeaInputScreen> createState() => _IdeaInputScreenState();
 }
 
-class _IdeaInputScreenState extends State<IdeaInputScreen> {
+class _IdeaInputScreenState extends ConsumerState<IdeaInputScreen> {
   final _controller = TextEditingController();
   final _focusNode = FocusNode();
   static const int _maxLength = 5000;
@@ -34,15 +39,12 @@ class _IdeaInputScreenState extends State<IdeaInputScreen> {
     super.dispose();
   }
 
-  void _onSubmit() {
+  Future<void> _onSubmit() async {
     if (!_canSubmit) return;
-    // TODO(sprint1): navigate to refinement screen with idea text
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text('Idea submitted: ${_controller.text.substring(0, 40)}...'),
-        backgroundColor: AppColors.secondary,
-      ),
-    );
+    final ideaText = _controller.text;
+
+    // Navigate to refinement screen — provider will handle validation + run
+    context.go(AppRoutes.refinement, extra: ideaText);
   }
 
   @override

--- a/apps/refinup_flutter/lib/features/refinement/screens/refinement_flow_screen.dart
+++ b/apps/refinup_flutter/lib/features/refinement/screens/refinement_flow_screen.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../../core/router/app_router.dart';
+import '../providers/refinement_provider.dart';
+import 'refinement_screen.dart';
+
+/// Riverpod-connected wrapper around [RefinementScreen].
+/// Triggers the refinement flow on mount and maps provider state to screen props.
+class RefinementFlowScreen extends ConsumerStatefulWidget {
+  final String ideaText;
+
+  const RefinementFlowScreen({super.key, required this.ideaText});
+
+  @override
+  ConsumerState<RefinementFlowScreen> createState() =>
+      _RefinementFlowScreenState();
+}
+
+class _RefinementFlowScreenState extends ConsumerState<RefinementFlowScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // Start the refinement pipeline on mount
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(refinementProvider.notifier).startRefinement(widget.ideaText);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(refinementProvider);
+
+    if (state.hasError) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Error')),
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.error_outline, size: 48, color: Colors.red),
+                const SizedBox(height: 16),
+                Text(
+                  state.errorMessage ?? 'Something went wrong.',
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 24),
+                ElevatedButton(
+                  onPressed: () {
+                    ref.read(refinementProvider.notifier).reset();
+                    context.go(AppRoutes.home);
+                  },
+                  child: const Text('Try Again'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Map provider round states to RefinementScreen model
+    final rounds = state.rounds
+        .map(
+          (r) => RoundOutput(
+            role: r.role,
+            text: r.text,
+            isStreaming: r.isStreaming,
+          ),
+        )
+        .toList();
+
+    return RefinementScreen(
+      ideaText: widget.ideaText,
+      rounds: rounds,
+      currentRoundIndex: state.currentRound,
+      isComplete: state.isComplete,
+      onShare: () {
+        // TODO(sprint2): generate shareable URL via Supabase
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Shareable link coming soon!')),
+        );
+      },
+      onNewIdea: () {
+        ref.read(refinementProvider.notifier).reset();
+        context.go(AppRoutes.home);
+      },
+    );
+  }
+}

--- a/apps/refinup_flutter/lib/main.dart
+++ b/apps/refinup_flutter/lib/main.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:refinup_model_registry/refinup_model_registry.dart';
+import 'core/router/app_router.dart';
 import 'core/theme/app_theme.dart';
-import 'features/refinement/screens/idea_input_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -10,7 +11,12 @@ void main() async {
   final registry = ModelRegistry();
   await registry.initialize();
 
-  runApp(const RefinUpApp());
+  runApp(
+    // ProviderScope is required for Riverpod
+    const ProviderScope(
+      child: RefinUpApp(),
+    ),
+  );
 }
 
 class RefinUpApp extends StatelessWidget {
@@ -18,13 +24,13 @@ class RefinUpApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
       title: 'RefinUp',
       debugShowCheckedModeBanner: false,
       theme: AppTheme.light,
       darkTheme: AppTheme.dark,
       themeMode: ThemeMode.system,
-      home: const IdeaInputScreen(),
+      routerConfig: appRouter,
     );
   }
 }

--- a/apps/refinup_flutter/pubspec.yaml
+++ b/apps/refinup_flutter/pubspec.yaml
@@ -20,11 +20,17 @@ dependencies:
     path: ../../packages/ai/refinup_model_registry
   refinup_agent_catalog:
     path: ../../packages/agents/refinup_agent_catalog
+  flutter_riverpod: ^2.5.1
+  riverpod_annotation: ^2.3.5
+  go_router: ^13.2.1
+  uuid: ^4.3.3
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^4.0.0
+  riverpod_generator: ^2.4.3
+  build_runner: ^2.4.9
 
 flutter:
   uses-material-design: true

--- a/forge/run-2-lessons.md
+++ b/forge/run-2-lessons.md
@@ -1,0 +1,21 @@
+# Forge Run 2 — Lessons
+
+## What Worked
+- Token-to-code translation from `tokens.md` → Dart was clean and direct
+- Splitting theme into 4 files (colors, typography, theme, spacing) keeps each file focused
+- Writing RefinementScreen as a pure stateless widget with injected data makes it easy to wire Riverpod later
+- How-it-works modal bottom sheet is a zero-cost UX improvement (no new screen, no routing needed)
+
+## What Could Be Better
+- Screens need `go_router` — currently no way to navigate from IdeaInputScreen to RefinementScreen
+- StepIndicator assumes fixed step count — should accept dynamic list
+- RefinementScreen currentStep calculation has an off-by-one risk with the "Your Idea" prefix step
+- No test files created — next run should add at least widget tests for StepIndicator and StreamingText
+
+## Run 3 Priorities (ordered)
+1. Add `go_router` + AppRouter
+2. Add Riverpod providers: `ideaProvider`, `refinementSessionProvider`
+3. Add `InputSanitizer` utility (required before any AI call)
+4. Add AppEvents constants (required before PostHog integration)
+5. Wire navigation: IdeaInputScreen → RefinementScreen
+6. Add widget tests for shared widgets

--- a/forge/run-2-summary.md
+++ b/forge/run-2-summary.md
@@ -1,0 +1,62 @@
+# Forge Run 2 — Summary
+
+**Date:** 2026-04-22
+**Branch:** forge/run-2-sprint1-ui → merged to main via PR #5
+**Commits:** 1 squash commit (10 files, 1276 insertions, 76 deletions)
+
+---
+
+## Sprint 1 — UI Foundation
+
+### Tasks Completed
+
+| Task | Status | Files |
+|------|--------|-------|
+| Design system: AppColors | done | `lib/core/theme/app_colors.dart` |
+| Design system: AppTextStyles | done | `lib/core/theme/app_text_styles.dart` |
+| Design system: AppTheme light/dark | done | `lib/core/theme/app_theme.dart` |
+| Design system: AppSpacing | done | `lib/core/theme/app_spacing.dart` |
+| Widget: StepIndicator | done | `lib/shared/widgets/step_indicator.dart` |
+| Widget: RoundBadge | done | `lib/shared/widgets/round_badge.dart` |
+| Widget: StreamingText | done | `lib/shared/widgets/streaming_text.dart` |
+| Screen: IdeaInputScreen | done | `lib/features/refinement/screens/idea_input_screen.dart` |
+| Screen: RefinementScreen | done | `lib/features/refinement/screens/refinement_screen.dart` |
+| main.dart: wire AppTheme | done | `lib/main.dart` |
+
+### GitHub Issues Created
+- #2: Design system theme
+- #3: Shared widgets
+- #4: IdeaInputScreen + RefinementScreen
+
+### PR
+- PR #5 merged (squash) to main
+
+---
+
+## Key Decisions
+
+- All widgets use Flutter Semantics — WCAG 2.1 AA rule from CLAUDE.md enforced
+- Input limit 5000 chars — security rule from CLAUDE.md enforced
+- Share CTA prominent at completion — top growth lever per MASTER_ANALYSIS
+- RoundBadge uses design token role colors (Critic=Red, Optimist=Emerald, Pragmatist=Indigo, Devil=Amber)
+- StreamingText shows thinking indicator when text empty + isStreaming — UX rule from CLAUDE.md
+
+---
+
+## What's Missing (for Run 3)
+
+- Riverpod state management layer (no providers yet)
+- AI pipeline service (Supabase Edge Function integration)
+- Input sanitizer utility
+- AppEvents / PostHog tracking
+- Navigation between screens (router)
+- Unit tests
+
+---
+
+## Lessons for Run 3
+
+1. Screens are stateless stubs — need Riverpod providers before they're testable
+2. Network layer (Supabase client, SSE) is the biggest unlock — without it screens are mocks
+3. Add `go_router` for navigation — currently no routing between screens
+4. Write `InputSanitizer` util before any AI call is wired up (security rule)


### PR DESCRIPTION
## Summary
- Add go_router based navigation (AppRouter) with home + refinement routes
- Add RefinementNotifier (Riverpod StateNotifierProvider) managing sequential AI round state with simulated streaming
- Add RefinementFlowScreen: connects provider state to RefinementScreen display
- Add InputSanitizer: enforces 5000-char limit, HTML strip, 7 prompt injection guards
- Add AppEvents + AppEventProps constants matching event-taxonomy.md
- Wire ProviderScope + MaterialApp.router into main.dart
- Add flutter_riverpod, go_router, uuid to pubspec.yaml

## Security
InputSanitizer runs before any AI call. Prompt injection patterns blocked:
- "ignore previous instructions"
- "system prompt"
- "you are now a"
- "disregard your"
- `<|im_start|>`, `[INST]` injection tokens

## Test plan
- [ ] `flutter analyze` — no errors
- [ ] Navigating to /refine with idea text triggers streaming rounds
- [ ] Bad input (<10 chars) shows validation error on RefinementFlowScreen
- [ ] Prompt injection strings rejected by InputSanitizer
- [ ] "New Idea" button resets provider and returns to home
- [ ] All 3 rounds complete sequentially before isComplete=true

Closes #6, #7, #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)