### PR TITLE
fix(refinement): re-mount guard for RefinementFlowScreen (T-010)

### DIFF
--- a/apps/refinup_flutter/lib/features/refinement/screens/refinement_flow_screen.dart
+++ b/apps/refinup_flutter/lib/features/refinement/screens/refinement_flow_screen.dart
@@ -18,12 +18,28 @@ class RefinementFlowScreen extends ConsumerStatefulWidget {
 }
 
 class _RefinementFlowScreenState extends ConsumerState<RefinementFlowScreen> {
+  /// Re-mount guard: ensures startRefinement is only triggered once per
+  /// screen lifecycle. Without this flag, hot reload or a quick re-mount
+  /// (e.g. nav-back-then-forward) could fire the pipeline twice and
+  /// corrupt state.
+  bool _started = false;
+
   @override
   void initState() {
     super.initState();
-    // Start the refinement pipeline on mount
+    // Start the refinement pipeline on mount — once and only once.
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      ref.read(refinementProvider.notifier).startRefinement(widget.ideaText);
+      if (_started || !mounted) return;
+      _started = true;
+
+      final notifier = ref.read(refinementProvider.notifier);
+      // If a previous session is still hanging around (nav-back-forward)
+      // reset before starting a fresh one.
+      final status = ref.read(refinementProvider).status;
+      if (status != RefinementStatus.idle) {
+        notifier.reset();
+      }
+      notifier.startRefinement(widget.ideaText);
     });
   }
 


### PR DESCRIPTION
## Summary
- Adds `_started` guard so `startRefinement` cannot fire twice on hot reload or fast re-mount.
- Resets the provider before starting if a non-idle session is detected (handles nav-back-then-forward).

## Test plan
- [x] `flutter analyze` — clean
- [x] Manual reasoning: guard + reset cover the two known reentry paths

Forge Run 4 / Sprint 4 / T-010.