### PR TITLE
refactor(router): typed RefinementParams + StepState clash fix (T-011)

### DIFF
--- a/apps/refinup_flutter/lib/core/router/app_router.dart
+++ b/apps/refinup_flutter/lib/core/router/app_router.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import '../../features/refinement/screens/idea_input_screen.dart';
 import '../../features/refinement/screens/refinement_flow_screen.dart';
+import 'refinement_params.dart';
+
+export 'refinement_params.dart';
 
 /// Named route paths
 class AppRoutes {
@@ -24,8 +27,9 @@ final appRouter = GoRouter(
       path: AppRoutes.refinement,
       name: 'refinement',
       builder: (context, state) {
-        final ideaText = state.extra as String? ?? '';
-        return RefinementFlowScreen(ideaText: ideaText);
+        // Accepts either a typed RefinementParams or a legacy raw String.
+        final params = RefinementParams.fromExtra(state.extra);
+        return RefinementFlowScreen(ideaText: params.ideaText);
       },
     ),
   ],

--- a/apps/refinup_flutter/lib/core/router/refinement_params.dart
+++ b/apps/refinup_flutter/lib/core/router/refinement_params.dart
@@ -1,0 +1,29 @@
+/// Typed parameter object passed via go_router `extra` when navigating to
+/// the refinement flow.
+///
+/// Using a dedicated class instead of a raw String prevents silent
+/// breakage if extra payload is extended later (e.g. preferred roles,
+/// session resume tokens).
+class RefinementParams {
+  final String ideaText;
+
+  const RefinementParams({required this.ideaText});
+
+  /// Backward-compatible factory for legacy raw-String extras.
+  factory RefinementParams.fromExtra(Object? extra) {
+    if (extra is RefinementParams) return extra;
+    if (extra is String) return RefinementParams(ideaText: extra);
+    return const RefinementParams(ideaText: '');
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is RefinementParams && other.ideaText == ideaText;
+
+  @override
+  int get hashCode => ideaText.hashCode;
+
+  @override
+  String toString() =>
+      'RefinementParams(ideaText: ${ideaText.length} chars)';
+}

--- a/apps/refinup_flutter/lib/features/refinement/screens/idea_input_screen.dart
+++ b/apps/refinup_flutter/lib/features/refinement/screens/idea_input_screen.dart
@@ -43,8 +43,11 @@ class _IdeaInputScreenState extends ConsumerState<IdeaInputScreen> {
     if (!_canSubmit) return;
     final ideaText = _controller.text;
 
-    // Navigate to refinement screen — provider will handle validation + run
-    context.go(AppRoutes.refinement, extra: ideaText);
+    // Navigate to refinement screen with a typed extra payload.
+    context.go(
+      AppRoutes.refinement,
+      extra: RefinementParams(ideaText: ideaText),
+    );
   }
 
   @override
@@ -81,9 +84,9 @@ class _IdeaInputScreenState extends ConsumerState<IdeaInputScreen> {
               // Step indicator — 3 steps: Input → Refine → Result
               StepIndicator(
                 steps: const [
-                  StepInfo(label: 'Your Idea', state: StepState.active),
-                  StepInfo(label: 'AI Rounds', state: StepState.pending, roleTag: 'Multi-AI'),
-                  StepInfo(label: 'Result', state: StepState.pending),
+                  StepInfo(label: 'Your Idea', state: RefinementStepState.active),
+                  StepInfo(label: 'AI Rounds', state: RefinementStepState.pending, roleTag: 'Multi-AI'),
+                  StepInfo(label: 'Result', state: RefinementStepState.pending),
                 ],
                 currentStep: 0,
               ),

--- a/apps/refinup_flutter/lib/features/refinement/screens/refinement_screen.dart
+++ b/apps/refinup_flutter/lib/features/refinement/screens/refinement_screen.dart
@@ -45,15 +45,15 @@ class RefinementScreen extends StatelessWidget {
 
     // Build step list from rounds
     final steps = [
-      const StepInfo(label: 'Your Idea', state: StepState.completed),
+      const StepInfo(label: 'Your Idea', state: RefinementStepState.completed),
       ...rounds.asMap().entries.map((e) {
-        final StepState state;
+        final RefinementStepState state;
         if (e.key < currentRoundIndex) {
-          state = StepState.completed;
+          state = RefinementStepState.completed;
         } else if (e.key == currentRoundIndex) {
-          state = StepState.active;
+          state = RefinementStepState.active;
         } else {
-          state = StepState.pending;
+          state = RefinementStepState.pending;
         }
         return StepInfo(
           label: 'Round ${e.key + 1}',
@@ -63,7 +63,7 @@ class RefinementScreen extends StatelessWidget {
       }),
       StepInfo(
         label: 'Result',
-        state: isComplete ? StepState.completed : StepState.pending,
+        state: isComplete ? RefinementStepState.completed : RefinementStepState.pending,
       ),
     ];
 

--- a/apps/refinup_flutter/lib/shared/widgets/step_indicator.dart
+++ b/apps/refinup_flutter/lib/shared/widgets/step_indicator.dart
@@ -4,17 +4,17 @@ import '../../core/theme/app_colors.dart';
 import '../../core/theme/app_spacing.dart';
 import '../../core/theme/app_text_styles.dart';
 
-enum StepState { pending, active, completed }
+enum RefinementStepState { pending, active, completed }
 
 class StepInfo {
   final String label;
   final String? roleTag;
-  final StepState state;
+  final RefinementStepState state;
 
   const StepInfo({
     required this.label,
     this.roleTag,
-    this.state = StepState.pending,
+    this.state = RefinementStepState.pending,
   });
 }
 
@@ -85,12 +85,12 @@ class _StepDot extends StatelessWidget {
     Widget child;
 
     switch (info.state) {
-      case StepState.completed:
+      case RefinementStepState.completed:
         bgColor = AppColors.primary;
         borderColor = AppColors.primary;
         child = const Icon(Icons.check, size: 14, color: Colors.white);
         break;
-      case StepState.active:
+      case RefinementStepState.active:
         bgColor = Colors.white;
         borderColor = roleColor;
         child = Text(
@@ -101,7 +101,7 @@ class _StepDot extends StatelessWidget {
           ),
         );
         break;
-      case StepState.pending:
+      case RefinementStepState.pending:
         bgColor = Colors.white;
         borderColor = AppColors.outline;
         child = Text(


### PR DESCRIPTION
## Summary
- Adds `RefinementParams` typed payload for `context.go(..., extra:)` with backward-compat factory.
- Resolves a latent ambiguous-import bug: local `StepState` clashed with `flutter/material.dart`'s `StepState`. Renamed to `RefinementStepState`.
- All 24 existing tests still pass; analyze is now clean of errors.

## Test plan
- [x] `flutter analyze lib/` — 0 errors (only pre-existing deprecation warnings)
- [x] `flutter test` — 24/24 passing

Forge Run 4 / Sprint 4 / T-011.